### PR TITLE
update pushplus

### DIFF
--- a/function/sendNotify.js
+++ b/function/sendNotify.js
@@ -55,7 +55,7 @@ let QYWX_AM = '';
 let IGOT_PUSH_KEY = '';
 
 // =======================================push+设置区域=======================================
-//官方文档：https://pushplus.hxtrip.com/
+//官方文档：https://www.pushplus.plus/
 //PUSH_PLUS_TOKEN：微信扫码登录后一对一推送或一对多推送下面的token(您的Token)，不提供PUSH_PLUS_USER则默认为一对一推送
 //PUSH_PLUS_USER： 一对多推送的“群组编码”（一对多推送下面->您的群组(如无则新建)->群组编码，如果您是创建群组人。也需点击“查看二维码”扫描绑定，否则不能接受群组消息推送）
 let PUSH_PLUS_TOKEN = '';
@@ -638,7 +638,7 @@ function pushPlusNotify(text, desp) {
         topic: `${PUSH_PLUS_USER}`
       };
       const options = {
-        url: `https://pushplus.hxtrip.com/send`,
+        url: `https://www.pushplus.plus/send`,
         body: JSON.stringify(body),
         headers: {
           'Content-Type': ' application/json'


### PR DESCRIPTION
根据pushplus官方提示，将接口域名更新为：https://www.pushplus.plus ，更新后token需要在新域名重新获取；
仅修改域名一项，根据需求判断是否合入。